### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
         "tqdm >= 4.64.1",
         "seaborn >= 0.11.2",
         "modisco-lite >= 2.0.0",
-        "tangermeme >= 0.2.0"
+        "tangermeme >= 0.2.3"
     ],
 )


### PR DESCRIPTION
The extract_loci function call used in PeakGenerator uses the ignore kwarg that wasn't implemented until tangermeme 0.2.3 (possibly 0.2.2? Fails in 0.2.1).